### PR TITLE
Fixed broken functions, quickstartified

### DIFF
--- a/python/ComputerVision/ComputerVisionQuickstart.py
+++ b/python/ComputerVision/ComputerVisionQuickstart.py
@@ -53,7 +53,9 @@ These variables are shared by several examples
 # Detect faces, Detect adult or racy content, Detect the color scheme, 
 # Detect domain-specific content, Detect image types, Detect objects
 local_image_path = "resources\\faces.jpg"
+# <snippet_remoteimage>
 remote_image_url = "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-sample-data-files/master/ComputerVision/Images/landmark.jpg"
+# </snippet_remoteimage>
 '''
 END - Quickstart variables
 '''

--- a/python/ComputerVision/ComputerVisionQuickstart.py
+++ b/python/ComputerVision/ComputerVisionQuickstart.py
@@ -10,29 +10,66 @@ import sys
 import time
 # </snippet_imports>
 
-#   The Quickstarts in this file are for the Computer Vision API for Microsoft
-#   Cognitive Services. In this file are Quickstarts for the following tasks:
-#     - Describing images
-#     - Categorizing images
-#     - Tagging images
-#     - Detecting faces
-#     - Detecting adult or racy content
-#     - Detecting the color scheme
-#     - Detecting domain-specific content (celebrities/landmarks)
-#     - Detecting image types (clip art/line drawing)
-#     - Detecting objects
-#     - Detecting brands
-#     - Recognizing printed and handwritten text with the batch read API
-#     - Recognizing printed text with OCR
+'''
+Computer Vision Quickstart for Microsoft Azure Cognitive Services. 
+Uses local and remote images in each example.
 
+Prerequisites:
+    - Install the Computer Vision SDK:
+      pip install --upgrade azure-cognitiveservices-vision-computervision
+    - Create folder and collect images: 
+      Create a folder called "resources" in your root folder.
+      Go to this website to download images:
+        https://github.com/Azure-Samples/cognitive-services-sample-data-files/tree/master/ComputerVision/Images
+      Add the following 7 images (or use your own) to your "resources" folder: 
+        faces.jpg, gray-shirt-logo.jpg, handwritten_text.jpg, landmark.jpg, 
+        objects.jpg, printed_text.jpg and type-image.jpg
+
+Run the entire file to demonstrate the following examples:
+    - Describing images
+    - Categorizing images
+    - Tagging images
+    - Detecting faces
+    - Detecting adult or racy content
+    - Detecting the color scheme
+    - Detecting domain-specific content (celebrities/landmarks)
+    - Detecting image types (clip art/line drawing)
+    - Detecting objects
+    - Detecting brands
+    - Recognizing handwritten text with the batch read API
+    - Recognizing printed text with OCR
+
+References:
+    - SDK: https://docs.microsoft.com/en-us/python/api/azure-cognitiveservices-vision-computervision/azure.cognitiveservices.vision.computervision?view=azure-python
+    - Documentaion: https://docs.microsoft.com/en-us/azure/cognitive-services/computer-vision/index
+    - API: https://westus.dev.cognitive.microsoft.com/docs/services/5adf991815e1060e6355ad44/operations/56f91f2e778daf14a499e1fa
+'''
+
+'''
+Quickstart variables
+These variables are shared by several examples
+'''
+# Images used for the examples: Describe an image, Categorize an image, Tag an image, 
+# Detect faces, Detect adult or racy content, Detect the color scheme, 
+# Detect domain-specific content, Detect image types, Detect objects
+local_image_path = "resources\\faces.jpg"
+remote_image_url = "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-sample-data-files/master/ComputerVision/Images/landmark.jpg"
+'''
+END - Quickstart variables
+'''
+
+'''
+Authenticate
+Authenticates your credentials and creates a client.
+'''
 # <snippet_vars>
-# Add your Computer Vision subscription key and endpoint to your environment variables.
+# Add your Computer Vision subscription key to your environment variables.
 if 'COMPUTER_VISION_SUBSCRIPTION_KEY' in os.environ:
     subscription_key = os.environ['COMPUTER_VISION_SUBSCRIPTION_KEY']
 else:
     print("\nSet the COMPUTER_VISION_SUBSCRIPTION_KEY environment variable.\n**Restart your shell or IDE for changes to take effect.**")
     sys.exit()
-
+# Add your Computer Vision endpoint to your environment variables.
 if 'COMPUTER_VISION_ENDPOINT' in os.environ:
     endpoint = os.environ['COMPUTER_VISION_ENDPOINT']
 else:
@@ -43,531 +80,656 @@ else:
 # <snippet_client>
 computervision_client = ComputerVisionClient(endpoint, CognitiveServicesCredentials(subscription_key))
 # </snippet_client>
+'''
+END - Authenticate
+'''
 
-#   Get a local image for analysis
-local_image_path = "resources\\faces.jpg"
-print("\n\nLocal image path:\n" + os.getcwd() + local_image_path)
-
-# Describe a local image by:
-#   1. Opening the binary file for reading.
-#   2. Defining what to extract from the image by initializing an array of VisualFeatureTypes.
-#   3. Calling the Computer Vision service's analyze_image_in_stream with the:
-#      - image
-#      - features to extract
-#   4. Displaying the image captions and their confidence values.
+'''
+Describe an image - local
+This example describes the contents of an image with the confidence score.
+'''
+print("===== Describe an image - local =====")
+# Open local image file
 local_image = open(local_image_path, "rb")
-local_image_description = computervision_client.describe_image_in_stream(local_image)
 
-print("\nCaptions from local image: ")
-if (len(local_image_description.captions) == 0):
-    print("No captions detected.")
+# Call API
+description_result = computervision_client.describe_image_in_stream(local_image)
+
+# Get the captions (descriptions) from the response, with confidence level
+print("Description of local image: ")
+if (len(description_result.captions) == 0):
+    print("No description detected.")
 else:
-    for caption in local_image_description.captions:
+    for caption in description_result.captions:
         print("'{}' with confidence {:.2f}%".format(caption.text, caption.confidence * 100))
-#  END - Describe a local image
-
-# <snippet_remoteimage>
-#   Get a remote image for analysis
-remote_image_url = "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-sample-data-files/master/ComputerVision/Images/landmark.jpg"
-print("\n\nRemote image URL:\n" + remote_image_url)
-# </snippet_remoteimage>
-#   END - Get a remote image for analysis
+print()
+'''
+END - Describe an image - local
+'''
 
 # <snippet_describe>
-# Describe a remote image by:
-#   1. Defining what to extract from the image by initializing an array of VisualFeatureTypes.
-#   2. Calling the Computer Vision service's analyze_image with the:
-#      - image URL
-#      - features to extract
-#   3. Displaying the image captions and their confidence values.
-remote_image_description = computervision_client.describe_image(remote_image_url)
+'''
+Describe an image - remote
+This example describes the contents of an image with the confidence score.
+'''
+print("===== Describe an image - remote =====")
+# Call API
+description_results = computervision_client.describe_image(remote_image_url )
 
-print("\nCaptions from remote image: ")
-if (len(remote_image_description.captions) == 0):
-    print("No captions detected.")
+# Get the captions (descriptions) from the response, with confidence level
+print("Description of remote image: ")
+if (len(description_results.captions) == 0):
+    print("No description detected.")
 else:
-    for caption in remote_image_description.captions:
+    for caption in description_results.captions:
         print("'{}' with confidence {:.2f}%".format(caption.text, caption.confidence * 100))
 # </snippet_describe>
-#   END - Describe a remote image
+print()
+'''
+END - Describe an image - remote
+'''
 
-
-# Categorize a local image by:
-#   1. Opening the binary file for reading.
-#   2. Defining what to extract from the image by initializing an array of VisualFeatureTypes.
-#   3. Calling the Computer Vision service's analyze_image_in_stream with the:
-#      - image
-#      - features to extract
-#   4. Displaying the image categories and their confidence values.
+'''
+Categorize an image -  local
+This example extracts categories from a local image with a confidence score
+'''
+print("===== Categorize an image - local =====")
+# Open local image file
 local_image = open(local_image_path, "rb")
+# Select visual feature type(s)
 local_image_features = ["categories"]
-local_image_analysis = computervision_client.analyze_image_in_stream(local_image, local_image_features)
+# Call API
+categorize_results_local = computervision_client.analyze_image_in_stream(local_image, local_image_features)
 
-print("\nCategories from local image: ")
-if (len(local_image_analysis.categories) == 0):
+# Print category results with confidence score
+print("Categories from local image: ")
+if (len(categorize_results_local.categories) == 0):
     print("No categories detected.")
 else:
-    for category in local_image_analysis.categories:
+    for category in categorize_results_local.categories:
         print("'{}' with confidence {:.2f}%".format(category.name, category.score * 100))
-#   END - Categorize a local image
+print()
+'''
+END - Categorize an image - local
+'''
 
 # <snippet_categorize>
-# Categorize a remote image by:
-#   1. Calling the Computer Vision service's analyze_image with the:
-#      - image URL
-#      - features to extract
-#   2. Displaying the image categories and their confidence values.
+'''
+Categorize an image - remote
+This example extracts (general) categories from a remote image with a confidence score.
+'''
+print("===== Categorize an image - remote =====")
+# Select the visual feature(s) you want.
 remote_image_features = ["categories"]
-remote_image_analysis = computervision_client.analyze_image(remote_image_url, remote_image_features)
+# Call API with URL and features
+categorize_results_remote = computervision_client.analyze_image(remote_image_url , remote_image_features)
 
-print("\nCategories from remote image: ")
-if (len(remote_image_analysis.categories) == 0):
+# Print results with confidence score
+print("Categories from remote image: ")
+if (len(categorize_results_remote.categories) == 0):
     print("No categories detected.")
 else:
-    for category in remote_image_analysis.categories:
+    for category in categorize_results_remote.categories:
         print("'{}' with confidence {:.2f}%".format(category.name, category.score * 100))
 # </snippet_categorize>
-#   END - Categorize a remote image
+print()
+'''
+ END - Categorize an image - remote
+'''
 
-# Tag a local image by:
-#   1. Opening the binary file for reading.
-#   2. Defining what to extract from the image by initializing an array of analyze_image_in_stream.
-#   3. Calling the Computer Vision service's tag_image_in_stream with the:
-#      - image
-#      - features to extract
-#   4. Displaying the image captions and their confidence values.
+'''
+Tag an image - local
+This example returns a tag (key word) for each thing in the image.
+'''
+print("===== Tag an image - local =====")
+# Open local image file
 local_image = open(local_image_path, "rb")
-local_image_tags = computervision_client.tag_image_in_stream(local_image)
+# Call API local image
+tags_result_local = computervision_client.tag_image_in_stream(local_image)
 
-print("\nTags in the local image: ")
-if (len(local_image_tags.tags) == 0):
+# Print results with confidence score
+print("Tags in the local image: ")
+if (len(tags_result_local.tags) == 0):
     print("No tags detected.")
 else:
-    for tag in local_image_tags.tags:
+    for tag in tags_result_local.tags:
         print("'{}' with confidence {:.2f}%".format(tag.name, tag.confidence * 100))
-#   END - Tag a local image
+print()
+'''
+END - Tag an image - local
+'''
 
 # <snippet_tags>
-# Tag a remote image by:
-#   1. Calling the Computer Vision service's analyze_image with the:
-#      - image URL
-#      - features to extract
-#   2. Displaying the image captions and their confidence values.
-remote_image_tags = computervision_client.tag_image(remote_image_url)
+'''
+Tag an image - remote
+This example returns a tag (key word) for each thing in the image.
+'''
+print("===== Tag an image - remote =====")
+# Call API with remote image
+tags_result_remote = computervision_client.tag_image(remote_image_url )
 
-print("\nTags in the remote image: ")
-if (len(remote_image_tags.tags) == 0):
+# Print results with confidence score
+print("Tags in the remote image: ")
+if (len(tags_result_remote.tags) == 0):
     print("No tags detected.")
 else:
-    for tag in remote_image_tags.tags:
+    for tag in tags_result_remote.tags:
         print("'{}' with confidence {:.2f}%".format(tag.name, tag.confidence * 100))
 # </snippet_tags>
-#   END - Tag a remote image
+print()
+'''
+END - Tag an image - remote
+'''
 
-# Detect faces in a local image by:
-#   1. Opening the binary file for reading.
-#   2. Defining what to extract from the image by initializing an array of VisualFeatureTypes.
-#   3. Calling the Computer Vision service's analyze_image_in_stream with the:
-#      - image
-#      - features to extract
-#   4. Displaying the image captions and their confidence values.
+'''
+Detect faces - local
+This example detects faces in a local image, gets their gender and age, 
+and marks them with a bounding box.
+'''
+print("===== Detect faces - local =====")
+# Open local image
 local_image = open(local_image_path, "rb")
+# Select visual features(s) you want
 local_image_features = ["faces"]
-local_image_analysis = computervision_client.analyze_image_in_stream(local_image, local_image_features)
+# Call API with local image and features
+detect_faces_results_local = computervision_client.analyze_image_in_stream(local_image, local_image_features)
 
-print("\nFaces in the local image: ")
-if (len(local_image_analysis.faces) == 0):
+# Print results with confidence score
+print("Faces in the local image: ")
+if (len(detect_faces_results_local.faces) == 0):
     print("No faces detected.")
 else:
-    for face in local_image_analysis.faces:
+    for face in detect_faces_results_local.faces:
         print("'{}' of age {} at location {}, {}, {}, {}".format(face.gender, face.age, \
         face.face_rectangle.left, face.face_rectangle.top, \
         face.face_rectangle.left + face.face_rectangle.width, \
         face.face_rectangle.top + face.face_rectangle.height))
-#   END - Detect faces in a local image
+print()
+'''
+END - Detect faces - local
+'''
 
 # <snippet_faces>
-# Detect faces in a remote image by:
-#   1. Calling the Computer Vision service's analyze_image with the:
-#      - image URL
-#      - features to extract
-#   2. Displaying the image captions and their confidence values.
+'''
+Detect faces - remote
+This example detects faces in a remote image, gets their gender and age, 
+and marks them with a bounding box.
+'''
+print("===== Detect faces - remote =====")
+# Get an image with faces
+remote_image_url_faces = "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-sample-data-files/master/ComputerVision/Images/faces.jpg"
+# Select the visual feature(s) you want.
 remote_image_features = ["faces"]
-remote_image_analysis = computervision_client.analyze_image(remote_image_url, remote_image_features)
+# Call the API with remote URL and features
+detect_faces_results_remote = computervision_client.analyze_image(remote_image_url_faces, remote_image_features)
 
-print("\nFaces in the remote image: ")
-if (len(remote_image_analysis.faces) == 0):
+# Print the results with gender, age, and bounding box
+print("Faces in the remote image: ")
+if (len(detect_faces_results_remote.faces) == 0):
     print("No faces detected.")
 else:
-    for face in remote_image_analysis.faces:
+    for face in detect_faces_results_remote.faces:
         print("'{}' of age {} at location {}, {}, {}, {}".format(face.gender, face.age, \
         face.face_rectangle.left, face.face_rectangle.top, \
         face.face_rectangle.left + face.face_rectangle.width, \
         face.face_rectangle.top + face.face_rectangle.height))
 # </snippet_faces>
-#   END - Detect faces in a remote image
+print()
+'''
+END - Detect faces - remote
+'''
 
-# Detect adult or racy content in a local image by:
-#   1. Opening the binary file for reading.
-#   2. Defining what to extract from the image by initializing an array of VisualFeatureTypes.
-#   3. Calling the Computer Vision service's analyze_image_in_stream with the:
-#      - image
-#      - features to extract
-#   4. Displaying the image captions and their confidence values.
+'''
+Detect adult or racy content - local
+This example detects adult or racy content in a local image, then prints the adult/racy score.
+The score is ranged 0.0 - 1.0 with smaller numbers indicating negative results.
+'''
+print("===== Detect adult or racy content - local =====")
+# Open local file
 local_image = open(local_image_path, "rb")
+# Select visual features you want
 local_image_features = ["adult"]
-local_image_analysis = computervision_client.analyze_image_in_stream(local_image, local_image_features)
+# Call API with local image and features
+detect_adult_results_local = computervision_client.analyze_image_in_stream(local_image, local_image_features)
 
-print("\nAnalyzing local image for adult or racy content ... ")
-print("Is adult content: {} with confidence {:.2f}%".format(local_image_analysis.adult.is_adult_content, local_image_analysis.adult.adult_score * 100))
-print("Has racy content: {} with confidence {:.2f}%".format(local_image_analysis.adult.is_racy_content, local_image_analysis.adult.racy_score * 100))
-#   END - Detect adult or racy content in a local image
+# Print results with adult/racy score
+print("Analyzing local image for adult or racy content ... ")
+print("Is adult content: {} with confidence {:.2f}".format(detect_adult_results_local .adult.is_adult_content, detect_adult_results_local .adult.adult_score * 100))
+print("Has racy content: {} with confidence {:.2f}".format(detect_adult_results_local .adult.is_racy_content, detect_adult_results_local .adult.racy_score * 100))
+print()
+'''
+END - Detect adult or racy content - local
+'''
 
 # <snippet_adult>
-# Detect adult or racy content in a remote image by:
-#   1. Calling the Computer Vision service's analyze_image with the:
-#      - image URL
-#      - features to extract
-#   2. Displaying the image captions and their confidence values.
+'''
+Detect adult or racy content - remote
+This example detects adult or racy content in a remote image, then prints the adult/racy score.
+The score is ranged 0.0 - 1.0 with smaller numbers indicating negative results.
+'''
+print("===== Detect adult or racy content - remote =====")
+# Select the visual feature(s) you want
 remote_image_features = ["adult"]
-remote_image_analysis = computervision_client.analyze_image(remote_image_url, remote_image_features)
+# Call API with URL and features
+detect_adult_results_remote = computervision_client.analyze_image(remote_image_url, remote_image_features)
 
-print("\nAnalyzing remote image for adult or racy content ... ")
-print("Is adult content: {} with confidence {:.2f}%".format(remote_image_analysis.adult.is_adult_content, local_image_analysis.adult.adult_score * 100))
-print("Has racy content: {} with confidence {:.2f}%".format(remote_image_analysis.adult.is_racy_content, local_image_analysis.adult.racy_score * 100))
+# Print results with adult/racy score
+print("Analyzing remote image for adult or racy content ... ")
+print("Is adult content: {} with confidence {:.2f}".format(detect_adult_results_remote.adult.is_adult_content, detect_adult_results_remote.adult.adult_score * 100))
+print("Has racy content: {} with confidence {:.2f}".format(detect_adult_results_remote.adult.is_racy_content, detect_adult_results_remote.adult.racy_score * 100))
 # </snippet_adult>
-#   END - Detect adult or racy content in a remote image
+print()
+'''
+END - Detect adult or racy content - remote
+'''
 
-# Detect the color scheme of a local image by:
-#   1. Opening the binary file for reading.
-#   2. Calling the Computer Vision service's analyze_image_in_stream with the:
-#      - image
-#      - features to extract
-#   3. Displaying color scheme of the local image.
+'''
+Detect color - local
+This example detects the different aspects of its color scheme in a local image.
+'''
+print("===== Detect color - local =====")
+# Open local image
 local_image = open(local_image_path, "rb")
+# Select visual feature(s) you want
 local_image_features = ["color"]
-local_image_analysis = computervision_client.analyze_image_in_stream(local_image, local_image_features)
+# Call API with local image and features
+detect_color_results_local = computervision_client.analyze_image_in_stream(local_image, local_image_features)
 
-print("\nColor scheme of the local image: ");
-print("Is black and white: ".format(local_image_analysis.color.is_bw_img))
-print("Accent color: 0x{}".format(local_image_analysis.color.accent_color))
-print("Dominant background color: {}".format(local_image_analysis.color.dominant_color_background))
-print("Dominant foreground color: {}".format(local_image_analysis.color.dominant_color_foreground))
-print("Dominant colors: {}".format(local_image_analysis.color.dominant_colors))
-#   END - Detect the color scheme in a local image
+# Print results of the color scheme detected
+print("Getting color scheme of the local image: ")
+print("Is black and white: {}".format(detect_color_results_local.color.is_bw_img))
+print("Accent color: {}".format(detect_color_results_local.color.accent_color))
+print("Dominant background color: {}".format(detect_color_results_local.color.dominant_color_background))
+print("Dominant foreground color: {}".format(detect_color_results_local.color.dominant_color_foreground))
+print("Dominant colors: {}".format(detect_color_results_local.color.dominant_colors))
+print()
+'''
+END - Detect color - local
+'''
 
 # <snippet_color>
-# Detect the color scheme of a remote image by:
-#   1. Calling the Computer Vision service's analyze_image with the:
-#      - image
-#      - features to extract
-#   2. Displaying color scheme of the local image.
+'''
+Detect color - remote
+This example detects the different aspects of its color scheme in a remote image.
+'''
+print("===== Detect color - remote =====")
+# Select the feature(s) you want
 remote_image_features = ["color"]
-remote_image_analysis = computervision_client.analyze_image(remote_image_url, remote_image_features)
+# Call API with URL and features
+detect_color_results_remote = computervision_client.analyze_image(remote_image_url, remote_image_features)
 
-print("\nColor scheme of the remote image: ");
-print("Is black and white: ".format(remote_image_analysis.color.is_bw_img))
-print("Accent color: 0x{}".format(remote_image_analysis.color.accent_color))
-print("Dominant background color: {}".format(remote_image_analysis.color.dominant_color_background))
-print("Dominant foreground color: {}".format(remote_image_analysis.color.dominant_color_foreground))
-print("Dominant colors: {}".format(remote_image_analysis.color.dominant_colors))
+# Print results of color scheme
+print("Getting color scheme of the remote image: ")
+print("Is black and white: {}".format(detect_color_results_remote.color.is_bw_img))
+print("Accent color: {}".format(detect_color_results_remote.color.accent_color))
+print("Dominant background color: {}".format(detect_color_results_remote.color.dominant_color_background))
+print("Dominant foreground color: {}".format(detect_color_results_remote.color.dominant_color_foreground))
+print("Dominant colors: {}".format(detect_color_results_remote.color.dominant_colors))
 # </snippet_color>
-#   END - Detect the color scheme in a remote image
+print()
+'''
+END - Detect color - remote
+'''
 
-#   Detect domain-specific content (celebrities/landmarks) in a local image by:
-#   1. Opening the binary file for reading.
-#   2. Calling the Computer Vision service's analyze_image_by_domain_in_stream with the:
-#      - domain-specific content to search for
-#      - image
-#   3. Displaying any domain-specific content (celebrities/landmarks).
+'''
+Detect domain-specific content - local
+This example detects celebrites and landmarks in local images.
+'''
+print("===== Detect domain-specific content - local =====")
+# Open local image file containing a celebtriy
 local_image = open(local_image_path, "rb")
-local_image_celebs = computervision_client.analyze_image_by_domain_in_stream("celebrities", local_image)
+# Call API with the type of content (celebrities) and local image
+detect_domain_results_celebs_local = computervision_client.analyze_image_by_domain_in_stream("celebrities", local_image)
 
-print("\nCelebrities in the local image:")
-if len(local_image_celebs.result["celebrities"]) == 0:
+# Print which celebrities (if any) were detected
+print("Celebrities in the local image:")
+if len(detect_domain_results_celebs_local.result["celebrities"]) == 0:
     print("No celebrities detected.")
 else:
-    for celeb in local_image_celebs.result["celebrities"]:
+    for celeb in detect_domain_results_celebs_local.result["celebrities"]:
         print(celeb["name"])
 
-local_image = open(local_image_path, "rb")
-local_image_landmarks = computervision_client.analyze_image_by_domain_in_stream("landmarks", local_image)
+# Open local image file containing a landmark
+local_image_path_landmark = "resources\\landmark.jpg"
+local_image_landmark = open(local_image_path_landmark, "rb")
+# Call API with type of content (landmark) and local image
+detect_domain_results_landmark_local = computervision_client.analyze_image_by_domain_in_stream("landmarks", local_image_landmark)
+print()
 
-print("\nLandmarks in the local image:")
-if len(local_image_landmarks.result["landmarks"]) == 0:
+# Print results of landmark detected
+print("Landmarks in the local image:")
+if len(detect_domain_results_landmark_local.result["landmarks"]) == 0:
     print("No landmarks detected.")
 else:
-    for landmark in local_image_landmarks.result["landmarks"]:
+    for landmark in detect_domain_results_landmark_local.result["landmarks"]:
         print(landmark["name"])
-#   END Detect domain-specific content (celebrities/landmarks) in a local image
+print()
+'''
+END - Detect domain-specific content - local
+'''
 
 # <snippet_celebs>
-#   Detect domain-specific content (celebrities/landmarks) in a remote image by:
-#   1. Calling the Computer Vision service's analyze_image_by_domain with the:
-#      - domain-specific content to search for
-#      - image
-#   2. Displaying any domain-specific content (celebrities/landmarks).
-remote_image_celebs = computervision_client.analyze_image_by_domain("celebrities", remote_image_url)
+'''
+Detect domain-specific content - remote
+This example detects celebrites and landmarks in remote images.
+'''
+print("===== Detect domain-specific content - remote =====")
+# URL of one or more celebrities
+remote_image_url_celebs = "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-sample-data-files/master/ComputerVision/Images/faces.jpg"
+# Call API with content type (celebrities) and URL
+detect_domain_results_celebs_remote = computervision_client.analyze_image_by_domain("celebrities", remote_image_url_celebs)
 
-print("\nCelebrities in the remote image:")
-if len(remote_image_celebs.result["celebrities"]) == 0:
+# Print detection results with name
+print("Celebrities in the remote image:")
+if len(detect_domain_results_celebs_remote.result["celebrities"]) == 0:
     print("No celebrities detected.")
 else:
-    for celeb in remote_image_celebs.result["celebrities"]:
+    for celeb in detect_domain_results_celebs_remote.result["celebrities"]:
         print(celeb["name"])
 # </snippet_celebs>
 # <snippet_landmarks>
-remote_image_landmarks = computervision_client.analyze_image_by_domain("landmarks", remote_image_url)
+# Call API with content type (landmarks) and URL
+detect_domain_results_landmarks = computervision_client.analyze_image_by_domain("landmarks", remote_image_url)
+print()
 
-print("\nLandmarks in the remote image:")
-if len(remote_image_landmarks.result["landmarks"]) == 0:
+print("Landmarks in the remote image:")
+if len(detect_domain_results_landmarks.result["landmarks"]) == 0:
     print("No landmarks detected.")
 else:
-    for landmark in remote_image_landmarks.result["landmarks"]:
+    for landmark in detect_domain_results_landmarks.result["landmarks"]:
         print(landmark["name"])
 # </snippet_landmarks>
-#   END Detect domain-specific content (celebrities/landmarks) in a remote image
+print()
+'''
+END - Detect domain-specific content - remote
+'''
 
-#   Detect image types (clip art/line drawing) of a local image by:
-#   1. Opening the binary file for reading.
-#   2. Calling the Computer Vision service's analyze_image_in_stream with the:
-#      - image
-#      - features to extract
-#   3. Displaying the image type.
-local_image = open(local_image_path, "rb")
+'''
+Detect image types - local
+This example detects an image's type (clip art/line drawing).
+'''
+print("===== Detect image types - local =====")
+# Open local image
+local_image_path_type = "resources\\type-image.jpg"
+local_image_type = open(local_image_path_type, "rb")
+# Select visual feature(s) you want
 local_image_features = VisualFeatureTypes.image_type
-local_image_analysis = computervision_client.analyze_image_in_stream(local_image, local_image_features)
+# Call API with local image and features
+detect_type_results_local = computervision_client.analyze_image_in_stream(local_image_type, local_image_features)
 
-print("\nImage type of local image:")
-if local_image_analysis.image_type.clip_art_type == 0:
+# Print type results with degree of accuracy
+print("Type of local image:")
+if detect_type_results_local.image_type.clip_art_type == 0:
     print("Image is not clip art.")
-elif local_image_analysis.image_type.line_drawing_type == 1:
+elif detect_type_results_local.image_type.line_drawing_type == 1:
     print("Image is ambiguously clip art.")
-elif local_image_analysis.image_type.line_drawing_type == 2:
+elif detect_type_results_local.image_type.line_drawing_type == 2:
     print("Image is normal clip art.")
 else:
     print("Image is good clip art.")
 
-if local_image_analysis.image_type.line_drawing_type == 0:
+if detect_type_results_local.image_type.line_drawing_type == 0:
     print("Image is not a line drawing.")
 else:
     print("Image is a line drawing")
-#   END - Detect image types (clip art/line drawing) of a local image
+print()
+'''
+END - Detect image types - local
+'''
 
 # <snippet_type>
-#   Detect image types (clip art/line drawing) of a remote image by:
-#   1. Calling the Computer Vision service's analyze_image with the:
-#      - image
-#      - features to extract
-#   2. Displaying the image type.
+'''
+Detect image types - remote
+This example detects an image's type (clip art/line drawing).
+'''
+print("===== Detect image types - remote =====")
+# Get URL of an image with a type
+remote_image_url_type = "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-sample-data-files/master/ComputerVision/Images/type-image.jpg"
+# Select visual feature(s) you want
 remote_image_features = VisualFeatureTypes.image_type
-remote_image_analysis = computervision_client.analyze_image(remote_image_url, remote_image_features)
+# Call API with URL and features
+detect_type_results_remote = computervision_client.analyze_image(remote_image_url_type, remote_image_features)
 
-print("\nImage type of remote image:")
-if remote_image_analysis.image_type.clip_art_type == 0:
+# Prints type results with degree of accuracy
+print("Type of remote image:")
+if detect_type_results_remote.image_type.clip_art_type == 0:
     print("Image is not clip art.")
-elif remote_image_analysis.image_type.line_drawing_type == 1:
+elif detect_type_results_remote.image_type.line_drawing_type == 1:
     print("Image is ambiguously clip art.")
-elif remote_image_analysis.image_type.line_drawing_type == 2:
+elif detect_type_results_remote.image_type.line_drawing_type == 2:
     print("Image is normal clip art.")
 else:
     print("Image is good clip art.")
 
-if remote_image_analysis.image_type.line_drawing_type == 0:
+if detect_type_results_remote.image_type.line_drawing_type == 0:
     print("Image is not a line drawing.")
 else:
     print("Image is a line drawing")
 # </snippet_type>
-#   END - Detect image types (clip art/line drawing) of a remote image
+print()
+'''
+END - Detect image types - remote
+'''
 
-#   Detect objects in a local image by:
-#   1. Opening the binary file for reading.
-#   2. Calling the Computer Vision service's detect_objects_in_stream with the:
-#      - image
-#   3. Displaying the location of the objects.
-local_image = open(local_image_path, "rb")
-local_image_objects = computervision_client.detect_objects_in_stream(local_image)
+'''
+Detect objects - local
+This example detects different kinds of objects with bounding boxes in a local image.
+'''
+print("===== Detect objects - local =====")
+# Get local image with different objects in it
+local_image_path_objects = "resources\\objects.jpg"
+local_image_objects = open(local_image_path_objects, "rb")
+# Call API with local image
+detect_objects_results_local = computervision_client.detect_objects_in_stream(local_image_objects)
 
-print("\nDetecting objects in local image:")
-if len(local_image_objects.objects) == 0:
+# Print results of detection with bounding boxes
+print("Detecting objects in local image:")
+if len(detect_objects_results_local.objects) == 0:
     print("No objects detected.")
 else:
-    for object in local_image_objects.objects:
+    for object in detect_objects_results_local.objects:
         print("object at location {}, {}, {}, {}".format( \
         object.rectangle.x, object.rectangle.x + object.rectangle.w, \
         object.rectangle.y, object.rectangle.y + object.rectangle.h))
-#   END - Detect objects in a local image
+print()
+'''
+END - Detect objects - local
+'''
 
 # <snippet_objects>
-#   Detect objects in a remote image by:
-#   1. Opening the binary file for reading.
-#   2. Calling the Computer Vision service's detect_objects with the:
-#      - image
-#      - features to extract
-#   3. Displaying the location of the objects.
-remote_image_objects = computervision_client.detect_objects(remote_image_url)
+'''
+Detect objects - remote
+This example detects different kinds of objects with bounding boxes in a remote image.
+'''
+print("===== Detect objects - remote =====")
+# Get URL image with different objects
+remote_image_url_objects = "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-sample-data-files/master/ComputerVision/Images/objects.jpg"
+# Call API with URL
+detect_objects_results_remote = computervision_client.detect_objects(remote_image_url_objects)
 
-print("\nDetecting objects in remote image:")
-if len(remote_image_objects.objects) == 0:
+# Print detected objects results with bounding boxes
+print("Detecting objects in remote image:")
+if len(detect_objects_results_remote.objects) == 0:
     print("No objects detected.")
 else:
-    for object in remote_image_objects.objects:
+    for object in detect_objects_results_remote.objects:
         print("object at location {}, {}, {}, {}".format( \
         object.rectangle.x, object.rectangle.x + object.rectangle.w, \
         object.rectangle.y, object.rectangle.y + object.rectangle.h))
 # </snippet_objects>
-#   END - Detect objects in a remote image
+print()
+'''
+END - Detect objects - remote
+'''
 
-#   Detect brands in a local image by:
-#   1. Opening the binary file for reading.
-#   2. Calling the Computer Vision service's analyze_image_in_stream with the:
-#      - image
-#      - features to extract
-#   3. Displaying brands detected in the image and their locations.
-local_image_path = "resources\\gray-shirt-logo.jpg"
-local_image = open(local_image_path, "rb")
+'''
+Detect brands - local
+This example detects common brands like logos and puts a bounding box around them.
+'''
+print("===== Detect brands - local =====")
+# Open image file
+local_image_path_shirt = "resources\\gray-shirt-logo.jpg"
+local_image_shirt = open(local_image_path_shirt, "rb")
+# Select the visual feature(s) you want
 local_image_features = ["brands"]
-local_image_analysis = computervision_client.analyze_image_in_stream(local_image, local_image_features)
+# Call API with image and features
+detect_brands_results_local = computervision_client.analyze_image_in_stream(local_image_shirt, local_image_features)
 
-print("\nDetecting brands in local image: ")
-if len(local_image_analysis.brands) == 0:
+# Print detection results with bounding box and confidence score
+print("Detecting brands in local image: ")
+if len(detect_brands_results_local.brands) == 0:
     print("No brands detected.")
 else:
-    for brand in local_image_analysis.brands:
+    for brand in detect_brands_results_local.brands:
         print("'{}' brand detected with confidence {:.1f}% at location {}, {}, {}, {}".format( \
         brand.name, brand.confidence * 100, brand.rectangle.x, brand.rectangle.x + brand.rectangle.w, \
         brand.rectangle.y, brand.rectangle.y + brand.rectangle.h))
-#   END - Detect brands in a local image
+print()
+'''
+END - Detect brands - local
+'''
 
 # <snippet_brands>
-#   Detect brands in a remote image by:
-#   1. Calling the Computer Vision service's analyze_image_in_stream with the:
-#      - image
-#      - features to extract
-#   3. Displaying brands detected in the image and their locations.
+'''
+Detect brands - remote
+This example detects common brands like logos and puts a bounding box around them.
+'''
+print("===== Detect brands - remote =====")
+# Get a URL with a brand logo
 remote_image_url = "https://docs.microsoft.com/en-us/azure/cognitive-services/computer-vision/images/gray-shirt-logo.jpg"
+# Select the visual feature(s) you want
 remote_image_features = ["brands"]
-remote_image_analysis = computervision_client.analyze_image(remote_image_url, remote_image_features)
+# Call API with URL and features
+detect_brands_results_remote = computervision_client.analyze_image(remote_image_url, remote_image_features)
 
-print("\nDetecting brands in remote image: ")
-if len(remote_image_analysis.brands) == 0:
+print("Detecting brands in remote image: ")
+if len(detect_brands_results_remote.brands) == 0:
     print("No brands detected.")
 else:
-    for brand in remote_image_analysis.brands:
+    for brand in detect_brands_results_remote.brands:
         print("'{}' brand detected with confidence {:.1f}% at location {}, {}, {}, {}".format( \
         brand.name, brand.confidence * 100, brand.rectangle.x, brand.rectangle.x + brand.rectangle.w, \
         brand.rectangle.y, brand.rectangle.y + brand.rectangle.h))
 # </snippet_brands>
-#   END - Detect brands in a remote image
+print()
+'''
+END - Detect brands - remote
+'''
 
-# Recognize text with the Read API in a local image by:
-#   1. Specifying whether the text to recognize is handwritten or printed.
-#   2. Calling the Computer Vision service's batch_read_file_in_stream with the:
-#      - context
-#      - image
-#      - text recognition mode
-#   3. Extracting the Operation-Location URL value from the batch_read_file_in_stream
-#      response
-#   4. Waiting for the operation to complete.
-#   5. Displaying the results.
-local_image_path = "resources\\handwritten_text.jpg"
-local_image = open(local_image_path, "rb")
-text_recognition_mode = TextRecognitionMode.handwritten
-num_chars_in_operation_id = 36
+'''
+Recognize handwritten text - local
+This example extracts text from a handwritten local image, then prints results.
+This API call can also recognize printed text (not shown).
+'''
+print("===== Detect handwritten text - local =====")
+# Get image of handwriting
+local_image_handwritten_path = "resources\\handwritten_text.jpg"
+# Open the image
+local_image_handwritten = open(local_image_handwritten_path, "rb")
 
-client_response = computervision_client.batch_read_file_in_stream(local_image, text_recognition_mode, raw=True)
-operation_location = client_response.headers["Operation-Location"]
-id_location = len(operation_location) - num_chars_in_operation_id
-operation_id = operation_location[id_location:]
+# Call API with image and raw response (allows you to get the operation location)
+recognize_handwriting_results = computervision_client.batch_read_file_in_stream(local_image_handwritten, raw=True)
+# Get the operation location (URL with ID as last appendage)
+operation_location_local = recognize_handwriting_results.headers["Operation-Location"]
+# Take the ID off and use to get results
+operation_id_local = operation_location_local.split("/")[-1]
 
-print("\n\nRecognizing text in a local image with the batch Read API ... \n")
-
+# Call the "GET" API and wait for the retrieval of the results
 while True:
-    result = computervision_client.get_read_operation_result(operation_id)
-    if result.status not in ['NotStarted', 'Running']:
+    recognize_handwriting_result = computervision_client.get_read_operation_result(operation_id_local)
+    if recognize_handwriting_result.status not in ['NotStarted', 'Running']:
         break
     time.sleep(1)
 
-if result.status == TextOperationStatusCodes.succeeded:
-    for text_result in result.recognition_results:
+# Print results, line by line
+if recognize_handwriting_result.status == TextOperationStatusCodes.succeeded:
+    for text_result in recognize_handwriting_result.recognition_results:
         for line in text_result.lines:
             print(line.text)
             print(line.bounding_box)
-            print()
-#   END - Recognizing printed and handwritten text with the batch read API in a local image
+print()
+'''
+END - Recognize handwritten text - local
+'''
 
 # <snippet_read_call>
-# Recognize text with the Read API in a remote image by:
-#   1. Specifying whether the text to recognize is handwritten or printed.
-#   2. Calling the Computer Vision service's batch_read_file_in_stream with the:
-#      - context
-#      - image
-#      - text recognition mode
-#   3. Extracting the Operation-Location URL value from the batch_read_file_in_stream
-#      response
-#   4. Waiting for the operation to complete.
-#   5. Displaying the results.
-remote_image_url = "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-sample-data-files/master/ComputerVision/Images/printed_text.jpg"
-text_recognition_mode = TextRecognitionMode.printed
-num_chars_in_operation_id = 36
+'''
+Recognize printed text - remote
+This example will extract printed text in an image, then print results, line by line.
+This API call can also recognize handwriting (not shown).
+'''
+print("===== Detect printed text - remote =====")
+# Get an image with printed text
+remote_image_printed_text_url = "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-sample-data-files/master/ComputerVision/Images/printed_text.jpg"
 
-client_response = computervision_client.batch_read_file(remote_image_url, text_recognition_mode, raw=True)
+# Call API with URL and raw response (allows you to get the operation location)
+recognize_printed_results = computervision_client.batch_read_file(remote_image_printed_text_url,  raw=True)
 # </snippet_read_call>
 # <snippet_read_response>
-operation_location = client_response.headers["Operation-Location"]
-id_location = len(operation_location) - num_chars_in_operation_id
-operation_id = operation_location[id_location:]
+# Get the operation location (URL with an ID at the end) from the response
+operation_location_remote = recognize_printed_results.headers["Operation-Location"]
+# Grab the ID from the URL
+operation_id = operation_location_remote.split("/")[-1]
 
-print("\nRecognizing text in a remote image with the batch Read API ... \n")
-
+# Call the "GET" API and wait for it to retrieve the results 
 while True:
-    result = computervision_client.get_read_operation_result(operation_id)
-    if result.status not in ['NotStarted', 'Running']:
+    get_printed_text_results = computervision_client.get_read_operation_result(operation_id)
+    if get_printed_text_results.status not in ['NotStarted', 'Running']:
         break
     time.sleep(1)
 
-if result.status == TextOperationStatusCodes.succeeded:
-    for text_result in result.recognition_results:
+# Print the detected text, line by line
+if get_printed_text_results.status == TextOperationStatusCodes.succeeded:
+    for text_result in get_printed_text_results.recognition_results:
         for line in text_result.lines:
             print(line.text)
             print(line.bounding_box)
-            print()
+print()
 # </snippet_read_response>
-#   END - Recognizing printed and handwritten text with the batch read API in a remote image
+'''
+END - Recognize printed text - remote
+'''
 
-# Recognize printed text with OCR in a local image by:
-#   1. Opening the binary file for reading.
-#   2. Calling the Computer Vision service's recognize_printed_text_in_stream with the:
-#      - image
-#   3. Displaying the lines of text and their bounding boxes.
-local_image_path = "resources\\printed_text.jpg"
-local_image = open(local_image_path, "rb")
+'''
+Recognize printed text with OCR - local
+This example will extract, using OCR, printed text in an image, then print results line by line.
+'''
+print("===== Detect printed text with OCR - local =====")
+# Get an image with printed text
+local_image_printed_text_path = "resources\\printed_text.jpg"
+local_image_printed_text = open(local_image_printed_text_path, "rb")
 
-print("\nRecognizing printed text with OCR on a local image ...\n")
-ocr_result = computervision_client.recognize_printed_text_in_stream(local_image)
-for region in ocr_result.regions:
+ocr_result_local = computervision_client.recognize_printed_text_in_stream(local_image_printed_text)
+for region in ocr_result_local.regions:
     for line in region.lines:
         print("Bounding box: {}".format(line.bounding_box))
         s = ""
         for word in line.words:
             s += word.text + " "
-        print(s + "\n")
-#   END - Recognize printed text with OCR in a local image
+        print(s)
+print()
+'''
+END - Recognize printed text with OCR - local
+'''
 
+'''
+Recognize printed text with OCR - remote
+This example will extract, using OCR, printed text in an image, then print results line by line.
+'''
+print("===== Detect printed text with OCR - remote =====")
+remote_printed_text_image_url = "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-sample-data-files/master/ComputerVision/Images/printed_text.jpg"
 
-# Recognize printed text with OCR in a remote image by:
-#   1. Calling the Computer Vision service's recognize_printed_text with the:
-#      - image
-#   2. Displaying the lines of text and their bounding boxes.
-remote_image_url = "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-sample-data-files/master/ComputerVision/Images/printed_text.jpg"
-
-print("\nRecognizing printed text with OCR on a remote image ...\n")
-ocr_result = computervision_client.recognize_printed_text(remote_image_url)
-for region in ocr_result.regions:
+ocr_result_remote = computervision_client.recognize_printed_text(remote_printed_text_image_url)
+for region in ocr_result_remote.regions:
     for line in region.lines:
         print("Bounding box: {}".format(line.bounding_box))
         s = ""
         for word in line.words:
             s += word.text + " "
-        print(s + "\n")
-#   END - Recognize printed text with OCR in a remote image
+        print(s)
+print()
+'''
+END - Recognize printed text with OCR - remote
+'''
+
+print("End of Computer Vision quickstart.")


### PR DESCRIPTION
## Purpose
The Read Batch File functions were broken (new constructor), so those were fixed. Also cleaned up a lot of comments, changed them to the quickstart standard. Typos and other missing API print statements were added. A few shared variables are now at the top. Also renamed several variables to avoid same-names in other examples of the quickstart.

## Does this introduce a breaking change?
The constructor for Read Batch File is different.
```
[x ] Yes
[ ] No
```

