### PR TITLE
Change getRectangle to output right coordinates

### DIFF
--- a/python/Face/FaceQuickstart.py
+++ b/python/Face/FaceQuickstart.py
@@ -165,8 +165,8 @@ def getRectangle(faceDictionary):
     rect = faceDictionary.face_rectangle
     left = rect.left
     top = rect.top
-    bottom = left + rect.height
-    right = top + rect.width
+    bottom = left + rect.width
+    right = top + rect.height
     return ((left, top), (bottom, right))
 
 


### PR DESCRIPTION
Hi, I found out that function:
```
def getRectangle(faceDictionary):
    rect = faceDictionary.face_rectangle
    left = rect.left
    top = rect.top
    bottom = left + rect.height
    right = top  + rect.width
    return ((left, top), (bottom, right))
```
Gives wrong coordinates, I think that changes that I'm proposing is the right one.
Also on my point of view notion of `top, left, height, width` is misleading and hard to understand. I think that better solution may be coordinates of two points like `xmin, ymin, xmax, ymax`, what usually we can find in the most of APIs.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Output right coordinates for bounding box

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ x ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* Check bounding box coordinates

## Other Information
<!-- Add any other helpful information that may be needed here. -->