### PR TITLE
Adding an environment variable setting for key

### DIFF
--- a/javascript/QnAMaker/sdk/qnamaker_quickstart.js
+++ b/javascript/QnAMaker/sdk/qnamaker_quickstart.js
@@ -33,7 +33,7 @@ const qnamaker_runtime = require("@azure/cognitiveservices-qnamaker-runtime");
 // </Dependencies>
 
 // <Resourcevariables>
-const authoringKey = "REPLACE-WITH-YOUR-QNA-MAKER-KEY";
+let authoringKey = process.env['QNAMAKER_AUTHORING_KEY'];
 const resourceName = "REPLACE-WITH-YOUR-RESOURCE-NAME";
 
 const authoringURL = `https://${resourceName}.cognitiveservices.azure.com`;


### PR DESCRIPTION
Adding an environment variable setting for qnamaker authoring key instead of keying it in this file
@diberry  FYI

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Adding an environment variable for the key instead of using it directly in the code.
Issue raised in https://github.com/MicrosoftDocs/azure-docs/issues/59546

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?
Uses the key from the environment variable rather than keying it in the code

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* Verify the environment variable QNAMAKER_AUTHORING_KEY is set to the authoring key of the QNAMaker resource 

## Other Information
<!-- Add any other helpful information that may be needed here. -->