### PR TITLE
This fixes an error when running the "Detect Image Types - remote" an…

### DIFF
--- a/python/ComputerVision/ComputerVisionQuickstart.py
+++ b/python/ComputerVision/ComputerVisionQuickstart.py
@@ -449,7 +449,7 @@ print("===== Detect Image Types - local =====")
 local_image_path_type = "resources\\type-image.jpg"
 local_image_type = open(local_image_path_type, "rb")
 # Select visual feature(s) you want
-local_image_features = VisualFeatureTypes.image_type
+local_image_features = [VisualFeatureTypes.image_type]
 # Call API with local image and features
 detect_type_results_local = computervision_client.analyze_image_in_stream(local_image_type, local_image_features)
 
@@ -482,7 +482,7 @@ print("===== Detect Image Types - remote =====")
 # Get URL of an image with a type
 remote_image_url_type = "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-sample-data-files/master/ComputerVision/Images/type-image.jpg"
 # Select visual feature(s) you want
-remote_image_features = VisualFeatureTypes.image_type
+remote_image_features = [VisualFeatureTypes.image_type]
 # Call API with URL and features
 detect_type_results_remote = computervision_client.analyze_image(remote_image_url_type, remote_image_features)
 


### PR DESCRIPTION
…d "Detect Image Types - Local" where the wrong parameter was used. This appears to be a regression due to some changes within the SDK.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

These changes fix and the following error that occurs in the "detect image types - local" and "detect image types - remote"

The cause of the error is the method `ComputerVisionClient.analyze_image()` expects a list and it coerces it to a list value and reads the individual characters of "ImageType" rather than the list of features.

```
===== Detect Image Types - remote =====
Traceback (most recent call last):
  File "C:\Users\kyichii\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\msrest\serialization.py", line 989, in serialize_enum
    enum_obj(result)
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.8_3.8.1776.0_x64__qbz5n2kfra8p0\lib\enum.py", line 315, in __call__
    return cls.__new__(cls, value)
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.8_3.8.1776.0_x64__qbz5n2kfra8p0\lib\enum.py", line 617, in __new__
    raise ve_exc
ValueError: 'I' is not a valid VisualFeatureTypes

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\kyichii\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\msrest\serialization.py", line 677, in query
    data = [
  File "C:\Users\kyichii\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\msrest\serialization.py", line 678, in <listcomp>
    self.serialize_data(d, internal_data_type, **kwargs) if d is not None else ""
  File "C:\Users\kyichii\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\msrest\serialization.py", line 771, in serialize_data
    return Serializer.serialize_enum(data, enum_obj=enum_type)
  File "C:\Users\kyichii\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\msrest\serialization.py", line 996, in serialize_enum
    raise SerializationError(error.format(attr, enum_obj))
msrest.exceptions.SerializationError: 'I' is not valid value for enum <enum 'VisualFeatureTypes'>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "ComputerVisionQuickstart.py", line 487, in <module>
    detect_type_results_remote = computervision_client.analyze_image(remote_image_url_type, remote_image_features)
  File "C:\Users\kyichii\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\azure\cognitiveservices\vision\computervision\operations\_computer_vision_client_operations.py", line 93, in analyze_image
    query_parameters['visualFeatures'] = self._serialize.query("visual_features", visual_features, '[VisualFeatureTypes]', div=',')
  File "C:\Users\kyichii\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\msrest\serialization.py", line 699, in query
    raise TypeError("{} must be type {}.".format(name, data_type))
TypeError: visual_features must be type [VisualFeatureTypes].
```


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
As per the instructions in the file
    - Install the Computer Vision SDK:
      pip install --upgrade azure-cognitiveservices-vision-computervision
    - Create folder and collect images: 
      Create a folder called "resources" in your root folder.
      Go to this website to download images:
        https://github.com/Azure-Samples/cognitive-services-sample-data-files/tree/master/ComputerVision/Images
      Add the following 7 images (or use your own) to your "resources" folder: 
        faces.jpg, gray-shirt-logo.jpg, handwritten_text.jpg, landmark.jpg, 
        objects.jpg, printed_text.jpg and type-image.jpg

- Change the following variables to a valid subscription key and computer vision endpoint at line 70 and 71
subscription_key = "<SUBSCRIPTION_KEY<"
endpoint = "<ENDPOINT_OF_COMPUTER_VISION_RESOURCE>"
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
cd cognitive-services-quickstart-code\python\ComputerVision
python ComputerVisionQuickstart.py
```

## What to Check
Verify that the following are valid
* "Detect Image Types - local" sample completes successfully
* "Detect Image Types - remote" sample completes successfully


## Other Information
There is no other information for this sample at this time. This does not resolve another outstanding issue as outlined https://github.com/Azure-Samples/cognitive-services-quickstart-code/issues/166 which will cause the sample to exit with a attribute error