### PR TITLE
This fixes an error that was caused by the breaking API change from t…

### DIFF
--- a/python/ComputerVision/ComputerVisionQuickstart.py
+++ b/python/ComputerVision/ComputerVisionQuickstart.py
@@ -678,22 +678,22 @@ local_image_handwritten_path = "resources\\handwritten_text.jpg"
 local_image_handwritten = open(local_image_handwritten_path, "rb")
 
 # Call API with image and raw response (allows you to get the operation location)
-recognize_handwriting_results = computervision_client.batch_read_file_in_stream(local_image_handwritten, raw=True)
+read_results = computervision_client.read_in_stream(local_image_handwritten, raw=True)
 # Get the operation location (URL with ID as last appendage)
-operation_location_local = recognize_handwriting_results.headers["Operation-Location"]
+operation_location_local = read_results.headers["Operation-Location"]
 # Take the ID off and use to get results
 operation_id_local = operation_location_local.split("/")[-1]
 
 # Call the "GET" API and wait for the retrieval of the results
 while True:
-    recognize_handwriting_result = computervision_client.get_read_operation_result(operation_id_local)
-    if recognize_handwriting_result.status not in ['notStarted', 'running']:
+    read_result = computervision_client.get_read_result(operation_id_local)
+    if read_result.status not in ['notStarted', 'running']:
         break
     time.sleep(1)
 
 # Print results, line by line
-if recognize_handwriting_result.status == OperationStatusCodes.succeeded:
-    for text_result in recognize_handwriting_result.analyze_result.read_results:
+if read_result.status == OperationStatusCodes.succeeded:
+    for text_result in read_result.analyze_result.read_results:
         for line in text_result.lines:
             print(line.text)
             print(line.bounding_box)
@@ -704,7 +704,7 @@ END - Batch Read File - local
 
 # <snippet_read_call>
 '''
-Batch Read File, recognize handwritten text - remote
+Read File, recognize handwritten text - remote
 This example will extract handwritten text in an image, then print results, line by line.
 This API call can also recognize handwriting (not shown).
 '''
@@ -713,25 +713,25 @@ print("===== Batch Read File - remote =====")
 remote_image_handw_text_url = "https://raw.githubusercontent.com/MicrosoftDocs/azure-docs/master/articles/cognitive-services/Computer-vision/Images/readsample.jpg"
 
 # Call API with URL and raw response (allows you to get the operation location)
-recognize_handw_results = computervision_client.read(remote_image_handw_text_url,  raw=True)
+raw_http_response = computervision_client.read(remote_image_handw_text_url,  raw=True)
 # </snippet_read_call>
 
 # <snippet_read_response>
 # Get the operation location (URL with an ID at the end) from the response
-operation_location_remote = recognize_handw_results.headers["Operation-Location"]
+operation_location_remote = raw_http_response.headers["Operation-Location"]
 # Grab the ID from the URL
 operation_id = operation_location_remote.split("/")[-1]
 
 # Call the "GET" API and wait for it to retrieve the results 
 while True:
-    get_handw_text_results = computervision_client.get_read_result(operation_id)
-    if get_handw_text_results.status not in ['notStarted', 'running']:
+    read_result = computervision_client.get_read_result(operation_id)
+    if read_result.status not in ['notStarted', 'running']:
         break
     time.sleep(1)
 
 # Print the detected text, line by line
-if get_handw_text_results.status == OperationStatusCodes.succeeded:
-    for text_result in get_handw_text_results.analyze_result.read_results:
+if read_result.status == OperationStatusCodes.succeeded:
+    for text_result in read_result.analyze_result.read_results:
         for line in text_result.lines:
             print(line.text)
             print(line.bounding_box)


### PR DESCRIPTION
…he python SDK commit:  https://github.com/Azure/azure-sdk-for-python/commit/99668db644fe606c24cc7cb553135b6614c10ffd

## Purpose
This commit should resolve the error that occurred as a result of the API changing in the following commit:  https://github.com/Azure/azure-sdk-for-python/commit/99668db644fe606c24cc7cb553135b6614c10ffd

This commit will also resolve the following issue: https://github.com/Azure-Samples/cognitive-services-quickstart-code/issues/166

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
* Ensure that the prerequisites required in the file are installed
    * Install the Computer Vision SDK:
      pip install --upgrade azure-cognitiveservices-vision-computervision
    * Create folder and collect images: 
      Create a folder called "resources" in your root folder.    
    * Go to this website to download images:
        https://github.com/Azure-Samples/cognitive-services-sample-data-files/tree/master/ComputerVision/Images
    * Add the following 7 images (or use your own) to your "resources" folder: 
        faces.jpg, gray-shirt-logo.jpg, handwritten_text.jpg, landmark.jpg, 
        objects.jpg, printed_text.jpg and type-image.jpg
* set variable 'endpoint' to the endpoint for a computer vision resource
* set variable 'subscription_key' to the subscriptoin key for the resource at the endpoint above
* change directory to python/Computervision/
* run 'python ComputerVisionQuickstart.py

## What to Check
Verify that the following are valid
All samples should complete without errors.

## Other Information
The issues caused to the batch_read_in_stream and batch_read was caused by an API breaking change. The changes here should resolve the issue and ensure that the terminology matches the new API.