### PR TITLE
Use AuthenticatePrediction instead of AuthenticateTraining

### DIFF
--- a/dotnet/CustomVision/ObjectDetection/Program.cs
+++ b/dotnet/CustomVision/ObjectDetection/Program.cs
@@ -26,7 +26,7 @@ namespace ObjectDetection
 
             // <snippet_maincalls>
             CustomVisionTrainingClient TrainingApi = AuthenticateTraining(ENDPOINT, trainingKey);
-            CustomVisionPredictionClient predictionApi = AuthenticateTraining(ENDPOINT, predictionKey);
+            CustomVisionPredictionClient predictionApi = AuthenticatePrediction(ENDPOINT, predictionKey);
 
             Project project = CreateProject(trainingApi);
             AddTags(trainingApi, project);


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* The main method calls the wrong function to authenticate itself even though it works the way it is. The other method is not called any other time and therefore is orphan code if not used. This PR is to reunite an orphan with it's parent.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
There should be no difference to the output of this program. It's simply that two methods were created by the original author to AuthenticateTraining, and AuthenticatePrediction. But AuthenticatePrediction is never called. AuthenticateTraining is called twice.

Technically, we can remove one of the methods and rename the other. But perhaps there was an intention by the author to separate the two for some training purpose.

