### PR TITLE
Correcting the reference to get the description or captions

### DIFF
--- a/python/ComputerVision/ImageAnalysisQuickstart.py
+++ b/python/ComputerVision/ImageAnalysisQuickstart.py
@@ -222,10 +222,10 @@ else:
 # Describe image
 # Get the captions (descriptions) from the response, with confidence level
 print("Description of remote image: ")
-if (len(results_remote.description) == 0):
+if (len(results_remote.description.captions) == 0):
     print("No description detected.")
 else:
-    for caption in results_remote.description:
+    for caption in results_remote.description.captions:
         print("'{}' with confidence {:.2f}%".format(caption.text, caption.confidence * 100))
 print()
 


### PR DESCRIPTION
Correcting the reference to get the description or captions from:
`results_remote.description` to `results_remote.description.captions`
Issue raised in docs repo.
https://github.com/MicrosoftDocs/azure-docs/issues/97909


## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...
The reference to get captions has changed to `results_remote.description.captions` where `results_remote` is the return object of `computervision_client.analyze_image()` call in this sample.
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?
Prints the correct description of the image used in this quickstart

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->