### PR TITLE
Added Predict_Endpoint variable for Prediction Endpoint

### DIFF
--- a/python/CustomVision/ImageClassification/CustomVisionQuickstart.py
+++ b/python/CustomVision/ImageClassification/CustomVisionQuickstart.py
@@ -29,7 +29,7 @@ ENDPOINT = os.environ["VISION_TRAINING_ENDPOINT"]
 training_key = os.environ["VISION_TRAINING_KEY"]
 prediction_key = os.environ["VISION_PREDICTION_KEY"]
 prediction_resource_id = os.environ["VISION_PREDICTION_RESOURCE_ID"]
-
+Predict_ENDPOINT = os.environ["VISION_PREDICTION_ENDPOINT"]
 # </snippet_creds>
 
 # <snippet_auth>
@@ -101,7 +101,7 @@ print ("Done!")
 # <snippet_test>
 # Now there is a trained endpoint that can be used to make a prediction
 prediction_credentials = ApiKeyCredentials(in_headers={"Prediction-key": prediction_key})
-predictor = CustomVisionPredictionClient(ENDPOINT, prediction_credentials)
+predictor = CustomVisionPredictionClient(Predict_ENDPOINT, prediction_credentials)
 
 with open(os.path.join (base_image_location, "Test/test_image.jpg"), "rb") as image_contents:
     results = predictor.classify_image(


### PR DESCRIPTION
Earlier code does not have predict_endpoint you use same training endpoint for both training and testing which generate error so create new variable for prediction endpoint and use it in prediction part

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->