### PR TITLE
Remove Unnecessary Line Continuation Chars for Face cURL Commands

### DIFF
--- a/curl/face/detect.ps1
+++ b/curl/face/detect.ps1
@@ -7,18 +7,18 @@ curl.exe -v -X POST "https://{resource endpoint}/face/v1.0/detect?returnFaceId=t
 
 # Create persongroup
 # <identify_create_persongroup>
-curl.exe -v -X PUT "https://{resource endpoint}/face/v1.0/largepersongroups/{largePersonGroupId}" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: {subscription key}" --data-ascii "{ `
-    ""name"": ""large-person-group-name"", `
-    ""userData"": ""User-provided data attached to the large person group."", `
-    ""recognitionModel"": ""recognition_04"" `
+curl.exe -v -X PUT "https://{resource endpoint}/face/v1.0/largepersongroups/{largePersonGroupId}" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: {subscription key}" --data-ascii "{
+    ""name"": ""large-person-group-name"",
+    ""userData"": ""User-provided data attached to the large person group."",
+    ""recognitionModel"": ""recognition_04""
 }" 
 # </identify_create_persongroup>
 
 # create persons 
 # <identify_create_person>
-curl.exe -v -X POST "https://{resource endpoint}/face/v1.0/largepersongroups/{largePersonGroupId}/persons" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: {subscription key}" --data-ascii "{ `
-    ""name"": ""Family1-Dad"", `
-    ""userData"": ""User-provided data attached to the person."" `
+curl.exe -v -X POST "https://{resource endpoint}/face/v1.0/largepersongroups/{largePersonGroupId}/persons" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: {subscription key}" --data-ascii "{
+    ""name"": ""Family1-Dad"",
+    ""userData"": ""User-provided data attached to the person.""
 }" 
 # </identify_create_person>
 
@@ -39,13 +39,13 @@ curl.exe -v "https://{resource endpoint}/face/v1.0/largepersongroups/{largePerso
 
 # call identify operation
 # <identify_identify>
-curl.exe -v -X POST "https://{resource endpoint}/face/v1.0/identify" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: {subscription key}" --data-ascii "{ `
-    ""largePersonGroupId"": ""INSERT_PERSONGROUP_ID"", `
-    ""faceIds"": [ `
-        ""INSERT_SOURCE_FACE_ID"" `
-    ], `
-    ""maxNumOfCandidatesReturned"": 1, `
-    ""confidenceThreshold"": 0.5 `
+curl.exe -v -X POST "https://{resource endpoint}/face/v1.0/identify" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: {subscription key}" --data-ascii "{
+    ""largePersonGroupId"": ""INSERT_PERSONGROUP_ID"",
+    ""faceIds"": [
+        ""INSERT_SOURCE_FACE_ID""
+    ],
+    ""maxNumOfCandidatesReturned"": 1,
+    ""confidenceThreshold"": 0.5
 }"
 # </identify_identify>
 
@@ -58,9 +58,9 @@ curl.exe -v -X DELETE "https://{resource endpoint}/face/v1.0/largepersongroups/{
 curl.exe -v -X POST "https://{resource endpoint}/face/v1.0/verify" `
 -H "Content-Type: application/json" `
 -H "Ocp-Apim-Subscription-Key: {subscription key}" `
---data-ascii "{ `
-    ""faceId"": ""INSERT_SOURCE_FACE_ID"", `
-    ""personId"": ""INSERT_PERSON_ID"", `
-    ""largePersonGroupId"": ""INSERT_PERSONGROUP_ID"" `
+--data-ascii "{
+    ""faceId"": ""INSERT_SOURCE_FACE_ID"",
+    ""personId"": ""INSERT_PERSON_ID"",
+    ""largePersonGroupId"": ""INSERT_PERSONGROUP_ID""
 }" 
 # </verify>

--- a/curl/face/detect.sh
+++ b/curl/face/detect.sh
@@ -38,18 +38,18 @@ curl -v -X POST "https://{resource endpoint}/face/v1.0/detect?returnFaceId=true&
 
 # Create persongroup
 # <identify_create_persongroup>
-curl -v -X PUT "https://{resource endpoint}/face/v1.0/largepersongroups/{largePersonGroupId}" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: {subscription key}" --data-ascii "{ \
-    \"name\": \"large-person-group-name\", \
-    \"userData\": \"User-provided data attached to the large person group.\", \
-    \"recognitionModel\": \"recognition_04\" \
+curl -v -X PUT "https://{resource endpoint}/face/v1.0/largepersongroups/{largePersonGroupId}" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: {subscription key}" --data-ascii "{
+    \"name\": \"large-person-group-name\",
+    \"userData\": \"User-provided data attached to the large person group.\",
+    \"recognitionModel\": \"recognition_04\"
 }" 
 # </identify_create_persongroup>
 
 # create persons 
 # <identify_create_person>
-curl -v -X POST "https://{resource endpoint}/face/v1.0/largepersongroups/{largePersonGroupId}/persons" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: {subscription key}" --data-ascii "{ \
-    \"name\": \"Family1-Dad\", \
-    \"userData\": \"User-provided data attached to the person.\" \
+curl -v -X POST "https://{resource endpoint}/face/v1.0/largepersongroups/{largePersonGroupId}/persons" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: {subscription key}" --data-ascii "{
+    \"name\": \"Family1-Dad\",
+    \"userData\": \"User-provided data attached to the person.\"
 }" 
 # </identify_create_person>
 
@@ -70,13 +70,13 @@ curl -v "https://{resource endpoint}/face/v1.0/largepersongroups/{largePersonGro
 
 # call identify operation
 # <identify_identify>
-curl -v -X POST "https://{resource endpoint}/face/v1.0/identify" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: {subscription key}" --data-ascii "{ \
-    \"largePersonGroupId\": \"INSERT_PERSONGROUP_ID\", \
-    \"faceIds\": [ \
-        \"INSERT_SOURCE_FACE_ID\" \
-    ], \
-    \"maxNumOfCandidatesReturned\": 1, \
-    \"confidenceThreshold\": 0.5 \
+curl -v -X POST "https://{resource endpoint}/face/v1.0/identify" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: {subscription key}" --data-ascii "{
+    \"largePersonGroupId\": \"INSERT_PERSONGROUP_ID\",
+    \"faceIds\": [
+        \"INSERT_SOURCE_FACE_ID\"
+    ],
+    \"maxNumOfCandidatesReturned\": 1,
+    \"confidenceThreshold\": 0.5
 }"
 # </identify_identify>
 
@@ -89,9 +89,9 @@ curl -v -X DELETE "https://{resource endpoint}/face/v1.0/largepersongroups/{larg
 curl -v -X POST "https://{resource endpoint}/face/v1.0/verify" \
 -H "Content-Type: application/json" \
 -H "Ocp-Apim-Subscription-Key: {subscription key}" \
---data-ascii "{ \
-    \"faceId\": \"INSERT_SOURCE_FACE_ID\", \
-    \"personId\": \"INSERT_PERSON_ID\", \
-    \"largePersonGroupId\": \"INSERT_PERSONGROUP_ID\" \
+--data-ascii "{
+    \"faceId\": \"INSERT_SOURCE_FACE_ID\",
+    \"personId\": \"INSERT_PERSON_ID\",
+    \"largePersonGroupId\": \"INSERT_PERSONGROUP_ID\"
 }" 
 # </verify>


### PR DESCRIPTION
## Purpose

Quotes already imply implicit line continuation, so there's no need to escape new line characters when dealing with quoted string literals.

For Bash, backslash inside quoted string does explicitly enable line continuation, and will also concatenate the lines into one. However this is unnecessary for JSON payloads.

For PowerShell, backtick inside quoted string also explicitly escapes the newline, but will NOT remove it. In other words, it is effectively a no-op that does nothing, as line continuation is already implied by quotes.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Pull Request Type

What kind of change does this Pull Request introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Documentation content changes
- [ ] Other... Please describe:


## How to Test

Run the updated cURL commands in UNIX Bash and PowerShell to ensure they work.


## Other Information

Ref:
* https://stackoverflow.com/a/35931689
* https://stackoverflow.com/a/53575932
